### PR TITLE
Add macro FROZEN_SIZE_T to be able to set custom size type.

### DIFF
--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -23,6 +23,7 @@
 #ifndef FROZEN_LETITGO_BASIC_TYPES_H
 #define FROZEN_LETITGO_BASIC_TYPES_H
 
+#include "frozen/bits/defines.h"
 #include "frozen/bits/exceptions.h"
 
 #include <array>
@@ -40,7 +41,7 @@ struct ignored_arg {};
 template <class T, std::size_t N>
 class cvector {
   T data_[N] = {}; // zero-initialization for scalar type T, default-initialized otherwise
-  std::size_t dsize_ = 0;
+  FROZEN_SIZE_T dsize_ = 0;
 
   template <class Iter>
   constexpr cvector(Iter iter, size_t size)
@@ -60,7 +61,7 @@ public:
   using const_iterator = const_pointer;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using size_type = std::size_t;
+  using size_type = FROZEN_SIZE_T;
   using difference_type = std::ptrdiff_t;
 
   // Constructors
@@ -359,7 +360,7 @@ public:
   using const_iterator = const_pointer;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using size_type = std::size_t;
+  using size_type = FROZEN_SIZE_T;
   using difference_type = std::ptrdiff_t;
 
   // Constructors
@@ -449,7 +450,7 @@ public:
   using const_iterator = const_pointer;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using size_type = std::size_t;
+  using size_type = FROZEN_SIZE_T;
   using difference_type = std::ptrdiff_t;
 
   // Constructors

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -29,6 +29,7 @@
 #include <array>
 #include <utility>
 #include <iterator>
+#include <limits>
 #include <string>
 
 namespace frozen {
@@ -40,6 +41,9 @@ struct ignored_arg {};
 
 template <class T, std::size_t N>
 class cvector {
+  // Make sure custom `FROZEN_SIZE_T` is big enough for templated usage.
+  static_assert(std::numeric_limits<FROZEN_SIZE_T>::max() >= N);
+
   T data_[N] = {}; // zero-initialization for scalar type T, default-initialized otherwise
   FROZEN_SIZE_T dsize_ = 0;
 

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -155,7 +155,7 @@ public:
 
     // Shift the existing values.
     iterator start = const_cast<iterator>(pos);
-    size_type num_to_shift = end() - start;
+    int64_t num_to_shift = (int64_t)(end() - start);
     for (iterator src = start + (num_to_shift - 1), dest = src + count;
          src >= start;
          --src, --dest) {
@@ -186,7 +186,7 @@ public:
 
     // Shift the existing values.
     iterator start = const_cast<iterator>(pos);
-    size_type num_to_shift = end() - start;
+    int64_t num_to_shift = (int64_t)(end() - start);
     for (iterator src = start + (num_to_shift - 1), dest = src + count;
          src >= start;
          --src, --dest) {

--- a/include/frozen/bits/defines.h
+++ b/include/frozen/bits/defines.h
@@ -55,4 +55,8 @@
   #define FROZEN_LETITGO_HAS_CHAR8T
 #endif
 
+#ifndef FROZEN_SIZE_T
+  #define FROZEN_SIZE_T std::size_t
+#endif
+
 #endif // FROZEN_LETITGO_DEFINES_H

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -54,7 +54,7 @@ struct pmh_buckets {
   // TODO: Come up with justification for this, should it not be O(log M)?
   static constexpr auto bucket_max = 2 * (1u << (log(M) / 2));
 
-  using bucket_t = cvector<std::size_t, bucket_max>;
+  using bucket_t = cvector<FROZEN_SIZE_T, bucket_max>;
   carray<bucket_t, M> buckets;
   uint64_t seed;
 
@@ -153,7 +153,7 @@ template <std::size_t M, class Hasher>
 struct pmh_tables {
   uint64_t first_seed_;
   carray<seed_or_index, M> first_table_;
-  carray<std::size_t, M> second_table_;
+  carray<FROZEN_SIZE_T, M> second_table_;
   Hasher hash_;
 
   // Looks up a given key, to find its expected index in carray<Item, N>
@@ -183,8 +183,8 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const carray<Item, N> &
   carray<seed_or_index, M> G; // Default constructed to "index 0"
 
   // H becomes the second hash table in the resulting pmh function
-  constexpr std::size_t UNUSED = std::numeric_limits<std::size_t>::max();
-  carray<std::size_t, M> H;
+  constexpr FROZEN_SIZE_T UNUSED = std::numeric_limits<FROZEN_SIZE_T>::max();
+  carray<FROZEN_SIZE_T, M> H;
   H.fill(UNUSED);
 
   // Step 3: Map the items in buckets into hash tables.

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -40,7 +40,7 @@ class basic_string {
   using chr_t = _CharT;
 
   chr_t const *data_;
-  std::size_t size_;
+  FROZEN_SIZE_T size_;
 
 public:
   template <std::size_t N>


### PR DESCRIPTION
This allows users to explicitly define the size of the `dsize_` internal member variable, that way it may be set to `uint32_t`, etc., and the size of a `frozen::vector` or other container is 100% deterministic and controllable across 32-bit and 64-bit platforms where necessary.

This is only done on internal member variables to avoid changing the STL-like APIs. This should be sufficient in general -- if `dsize_` is a `uint32_t` and the user calls a function passing in a `size_t` value > 2^32, the container capacity will always be smaller than that, and the `size < capacity` check will work correctly. It is also extremely rare for anyone to require a container with a more than 2^32 elements in the first place.