### PR TITLE
Don't call default constructor for cvector data.

### DIFF
--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -146,6 +146,11 @@ public:
     if (dsize_ == N) {
       FROZEN_THROW_OR_ABORT(std::out_of_range("Emplacing into full vector"));
     }
+    // Since this class declares it's member data as `T data_[N];` the data will
+    // always have valid constructed instances. Since the placement new operator
+    // won't implicitly call the the destructor, it needs to be called
+    // explicitly. This isn't needed for the insert/push operations since they
+    // use constructors that will implicitly call the destructor.
     data_[dsize_].~T();
     new (data_ + dsize_) T(std::forward<Args>(args)...);
     dsize_++;

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -143,6 +143,10 @@ public:
 
   template <class... Args>
   constexpr void emplace_back(Args &&...args) {
+    if (dsize_ == N) {
+      FROZEN_THROW_OR_ABORT(std::out_of_range("Emplacing into full vector"));
+    }
+    data_[dsize_].~T();
     new (data_ + dsize_) T(std::forward<Args>(args)...);
     dsize_++;
   }

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -44,7 +44,7 @@ class cvector {
   // Make sure custom `FROZEN_SIZE_T` is big enough for templated usage.
   static_assert(std::numeric_limits<FROZEN_SIZE_T>::max() >= N);
 
-  T data_[N] = {}; // zero-initialization for scalar type T, default-initialized otherwise
+  T data_[N];
   FROZEN_SIZE_T dsize_ = 0;
 
   template <class Iter>

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -151,6 +151,9 @@ public:
     // won't implicitly call the the destructor, it needs to be called
     // explicitly. This isn't needed for the insert/push operations since they
     // use constructors that will implicitly call the destructor.
+    //
+    // This is OK for primitives as well since the compiler has a special case
+    // to NOP this operation if a template calls the destructor for a primitive.
     data_[dsize_].~T();
     new (data_ + dsize_) T(std::forward<Args>(args)...);
     dsize_++;


### PR DESCRIPTION
Creating a vector with an un-copyable object fails on ARM GCC due to the line:

`T data_[N] = {}; // zero-initialization for scalar type T, default-initialized otherwise`

For class/structs, the initialization with the default constructor happens automatically, and there's not much reason to zero initialize primitives since they shouldn't be accesses since they are in invalid entries.

In addition I noticed the de-constructor wasn't being called for the emplace operations.

This made me realize there's a bit of a weirdness around how the deconstruction works for clear/pop operations. The deconstructor isn't called for those cases. Only if the whole vector is deconstructed, or the freed indexes get overriden will the deconstructor be called. This may cause unexpected behavior like not freeing a shared pointer.

I'm not fixing that here though since it's a bit non-trivial and has behavior and performance implications.